### PR TITLE
Made subdivison optional in public holidays

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "scripts": {
     "build": "tsup src/index.ts --format cjs,esm --dts",
     "lint": "tsc",

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,7 +101,7 @@ export class Holiday {
     country: string,
     startDate: Date,
     endDate: Date,
-    subdivision: string,
+    subdivision?: string,
     language?: string,
   ) {
     const paramsArray = [


### PR DESCRIPTION
subdivison aren't required in the actuall api see https://www.openholidaysapi.org/en/#public-holidays