### PR TITLE
fix: add "Optional" as value for holiday types

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "scripts": {
     "build": "tsup src/index.ts --format cjs,esm --dts",
     "lint": "tsc",

--- a/src/schemas/holidays.ts
+++ b/src/schemas/holidays.ts
@@ -11,6 +11,7 @@ const holidayType = z.union([
   z.literal("School"),
   z.literal("BackToSchool"),
   z.literal("EndOfLessons"),
+  z.literal("Optional"),
 ]);
 
 const holidaySchema = z.object({


### PR DESCRIPTION
```bash
curl -X 'GET' \
  'https://openholidaysapi.org/PublicHolidays?countryIsoCode=CH&validFrom=2024-01-01&validTo=2024-12-31&languageIsoCode=DE&subdivisionCode=CH-ZH' \
  -H 'accept: application/json'
```